### PR TITLE
OT Requirements

### DIFF
--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/config/BetterDexRewardsConfig.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/config/BetterDexRewardsConfig.java
@@ -26,8 +26,6 @@ public class BetterDexRewardsConfig extends AbstractYamlConfig {
                                                                  "admin", "password", "BetterDexRewards"
     );
 
-    private boolean requiresOriginalTrainerToReward = false;
-
     private ConfigInterface configInterface = new ConfigInterface();
 
     private PositionableConfigItem infoItem = new PositionableConfigItem(
@@ -83,6 +81,8 @@ public class BetterDexRewardsConfig extends AbstractYamlConfig {
             Lists.newArrayList(),
             8, 5, Collections.emptyMap()
     );
+
+    private boolean requiresOriginalTrainerToReward = false;
 
     private int messageDelaySeconds = 60;
 

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/config/BetterDexRewardsConfig.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/config/BetterDexRewardsConfig.java
@@ -26,6 +26,8 @@ public class BetterDexRewardsConfig extends AbstractYamlConfig {
                                                                  "admin", "password", "BetterDexRewards"
     );
 
+    private boolean requiresOriginalTrainerToReward = false;
+
     private ConfigInterface configInterface = new ConfigInterface();
 
     private PositionableConfigItem infoItem = new PositionableConfigItem(
@@ -131,6 +133,10 @@ public class BetterDexRewardsConfig extends AbstractYamlConfig {
 
     public SQLDatabaseDetails getDatabase() {
         return this.database;
+    }
+
+    public boolean getRequiresOriginalTrainerToReward() {
+        return this.requiresOriginalTrainerToReward;
     }
 
     public Map<String, DexCompletion> getRewardStages() {

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
@@ -37,6 +37,10 @@ public class DexRewardsListener {
         }
 
         if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
+            if (event.pokemon.getOriginalTrainerUUID() == null) {
+                return;
+            }
+
             if (!(event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID()))) {
                 event.setCanceled(true);
                 return;

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
@@ -33,13 +33,11 @@ public class DexRewardsListener {
         }
 
         if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
-            if (event.pokemon.getOriginalTrainerUUID() == null) {
-                return;
-            }
-
-            if (!(event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID()))) {
-                event.setCanceled(true);
-                return;
+            if (event.pokemon.getOriginalTrainerUUID() != null) {
+                if (!(event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID()))) {
+                    event.setCanceled(true);
+                    return;
+                }
             }
         }
 

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
@@ -36,16 +36,16 @@ public class DexRewardsListener {
             return;
         }
 
+        if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
+            if (!(event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID()))) {
+                event.setCanceled(true);
+                return;
+            }
+        }
+
         UtilConcurrency.runAsync(() -> {
             ForgeEnvyPlayer player = this.mod.getPlayerManager().getPlayer(event.uuid);
             DexRewardsAttribute attribute = player.getAttribute(BetterDexRewards.class);
-
-            if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
-                if (!event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID())) {
-                    event.setCanceled(true);
-                    return;
-                }
-            }
 
             if (attribute == null) {
                 return;

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
@@ -32,10 +32,6 @@ public class DexRewardsListener {
             return;
         }
 
-        if (event.pokemon == null) {
-            return;
-        }
-
         if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
             if (event.pokemon.getOriginalTrainerUUID() == null) {
                 return;

--- a/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
+++ b/forge16/src/main/java/com/envyful/better/dex/rewards/forge/listener/DexRewardsListener.java
@@ -32,9 +32,20 @@ public class DexRewardsListener {
             return;
         }
 
+        if (event.pokemon == null) {
+            return;
+        }
+
         UtilConcurrency.runAsync(() -> {
             ForgeEnvyPlayer player = this.mod.getPlayerManager().getPlayer(event.uuid);
             DexRewardsAttribute attribute = player.getAttribute(BetterDexRewards.class);
+
+            if (this.mod.getConfig().getRequiresOriginalTrainerToReward()) {
+                if (!event.pokemon.getOriginalTrainerUUID().equals(entityPlayerMP.getUUID())) {
+                    event.setCanceled(true);
+                    return;
+                }
+            }
 
             if (attribute == null) {
                 return;
@@ -59,5 +70,4 @@ public class DexRewardsListener {
             }
         });
     }
-
 }


### PR DESCRIPTION
- Add a config option to specify if the player must be the Pokémon's OT for it to register to the PokéDex/Rewards